### PR TITLE
Add loongarch64 support

### DIFF
--- a/port/atomic_pointer.h
+++ b/port/atomic_pointer.h
@@ -38,6 +38,8 @@
 #define ARCH_CPU_ARM_FAMILY 1
 #elif defined(__ppc__) || defined(__powerpc__) || defined(__powerpc64__)
 #define ARCH_CPU_PPC_FAMILY 1
+#elif defined(__loongarch64)
+#define ARCH_CPU_LOONGARCH64_FAMILY 1
 #endif
 
 namespace leveldb {
@@ -99,6 +101,13 @@ inline void MemoryBarrier() {
   // TODO for some powerpc expert: is there a cheaper suitable variant?
   // Perhaps by having separate barriers for acquire and release ops.
   asm volatile("sync" : : : "memory");
+}
+#define LEVELDB_HAVE_MEMORY_BARRIER
+
+// LoongArch64
+#elif defined(ARCH_CPU_LOONGARCH64_FAMILY) && defined(__GNUC__)
+inline void MemoryBarrier() {
+  __asm__ __volatile__ ("dbar  0" : : : "memory");
 }
 #define LEVELDB_HAVE_MEMORY_BARRIER
 


### PR DESCRIPTION
LoongArch is a risc architecture, like RISCV. This PR is used to support LoongArch.